### PR TITLE
examples: mark the pointer as volatile

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -2,10 +2,12 @@ SRCS := $(wildcard *.c)
 
 EXECS := $(SRCS:.c=)
 
+CC ?= gcc
+
 all : $(EXECS)
 
 %: %.c
-	gcc $< -o $@
+	$(CC) $< -o $@
 
 clean:
 	rm -f $(EXECS)

--- a/example/example.c
+++ b/example/example.c
@@ -9,7 +9,7 @@ TEST(test_two) {
 }
 
 TEST(test_three) {
-	int *p = NULL;
+	int *volatile p = NULL;
 	*p = 42;
 	ASSERT_EQUAL_INT(42, *p);
 }

--- a/example/example2.c
+++ b/example/example2.c
@@ -9,7 +9,7 @@ TEST(test_two) {
 }
 
 TEST(test_three) {
-	int *p = NULL;
+	int *volatile p = NULL;
 	*p = 42;
 	ASSERT_EQUAL_INT(42, *p);
 }


### PR DESCRIPTION
So compiling test_three function from the example.c, using Clang, (optimizations enabled) causes an infinite loop and makes the test result ok (it should segfault). GCC however doesn't cause this behavior and just prints the expected result. test_three from example2.c, has the same behavior, except after ok, it just falls to next function where it fails and exits (thus doesn't cause the loop).

GCC generates (-O3)
	leaq	test_three(%rip), %rsi
Clang generates (-O3)
	leaq	test_three(%rip), %rdx

And changing rdx to point back to rsi results test segfault (ok behavior).

makefile: By default CC points to the default C compiler on the host system, so there's no need to explicitly set this to gcc.